### PR TITLE
File.exists? has been removed in CRuby3.2.0

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -18,7 +18,7 @@ MRuby::Gem::Specification.new('mruby-vedis') do |spec|
 
   FileUtils.mkdir_p build_dir
 
-  if ! File.exists? vedis_dir
+  if ! File.exist? vedis_dir
     Dir.chdir(build_dir) do
       e = {}
       run_command e, 'git clone https://github.com/symisc/vedis.git'


### PR DESCRIPTION
File.exists?がCRuby3.2.0で削除されたのでFile.exist?に置き換えます。